### PR TITLE
Proposal for an automatic setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ networks:
     external: true
 ```
 This way, you can use the services' hostname directly in the `target_ip` parameters. Moreover, as the services are connected to the proxy network they are reachable inside it without exposing or changing any port, but not reachable from the outside.
+
+### Automatic script
+All the above configuration can be done with the provided setup script. Either clone the repository and run it or run
+```
+curl -sL https://raw.githubusercontent.com/ByteLeMani/ctf_proxy/main/setup_proxy.py | python3
+```
+The script will work as long as it is called from inside ctf_proxy or besides all the services
 ### CLI Example
 Clone the repository, install the required packages and run it:
 ```bash

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This way, you can use the services' hostname directly in the `target_ip` paramet
 ### Automatic script
 All the above configuration can be done with the provided setup script. Either clone the repository, install ruamel.yaml and run the script or run
 ```
-pip install ruamel.yaml; curl -sL https://raw.githubusercontent.com/ByteLeMani/ctf_proxy/main/setup_proxy.py; ./setup_proxy.py
+pip install ruamel.yaml; curl -s https://raw.githubusercontent.com/ByteLeMani/ctf_proxy/main/setup_proxy.py > setup_proxy.py; python3 setup_proxy.py
 ```
 The script will work as long as it is called from inside ctf_proxy or besides all the services. In the latter case it will clone ctf_proxy before configuring it.
 ### CLI Example

--- a/README.md
+++ b/README.md
@@ -100,11 +100,13 @@ networks:
 This way, you can use the services' hostname directly in the `target_ip` parameters. Moreover, as the services are connected to the proxy network they are reachable inside it without exposing or changing any port, but not reachable from the outside.
 
 ### Automatic script
-All the above configuration can be done with the provided setup script. Either clone the repository, install ruamel.yaml and run the script or run
+All the above configuration can be done with the provided setup script. Either clone the repository, install ruamel.yaml and run the script or directly run
 ```
 pip install ruamel.yaml; curl -s https://raw.githubusercontent.com/ByteLeMani/ctf_proxy/main/setup_proxy.py > setup_proxy.py; python3 setup_proxy.py
 ```
 The script will work as long as it is called from inside ctf_proxy or besides all the services. In the latter case it will clone ctf_proxy before configuring it.
+You can manually provide paths for the services as arguments when you call the script. If you don't it will automatically scan cwd and look for services, asking for confirmation.
+
 ### CLI Example
 Clone the repository, install the required packages and run it:
 ```bash

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ networks:
 This way, you can use the services' hostname directly in the `target_ip` parameters. Moreover, as the services are connected to the proxy network they are reachable inside it without exposing or changing any port, but not reachable from the outside.
 
 ### Automatic script
-All the above configuration can be done with the provided setup script. Either clone the repository and run it or run
+All the above configuration can be done with the provided setup script. Either clone the repository, install ruamel.yaml and run the script or run
 ```
-curl -sL https://raw.githubusercontent.com/ByteLeMani/ctf_proxy/main/setup_proxy.py | python3
+pip install ruamel.yaml; curl -sL https://raw.githubusercontent.com/ByteLeMani/ctf_proxy/main/setup_proxy.py; ./setup_proxy.py
 ```
-The script will work as long as it is called from inside ctf_proxy or besides all the services
+The script will work as long as it is called from inside ctf_proxy or besides all the services. In the latter case it will clone ctf_proxy before configuring it.
 ### CLI Example
 Clone the repository, install the required packages and run it:
 ```bash

--- a/setup_proxy.py
+++ b/setup_proxy.py
@@ -7,7 +7,7 @@ import ruamel.yaml  # pip install ruamel.yaml
 
 """
 Why not just use the included yaml package?
-Because this one preservs order and comments (and also allows adding them)
+Because this one preserves order and comments (and also allows adding them)
 """
 
 from pathlib import Path

--- a/setup_proxy.py
+++ b/setup_proxy.py
@@ -214,6 +214,7 @@ def restart_services():
 if __name__ == "__main__":
     if Path(os.getcwd()).name == "ctf_proxy":
         os.chdir("..")
+    print("\n")
     services_dict = parse_services()
     edit_services()
     configure_proxy()

--- a/setup_proxy.py
+++ b/setup_proxy.py
@@ -7,7 +7,7 @@ import ruamel.yaml  # pip install ruamel.yaml
 
 """
 Why not just use the included yaml package?
-Because this one preserves order and comments (and also allows adding them)
+Because this one preservs order and comments (and also allows adding them)
 """
 
 from pathlib import Path
@@ -83,7 +83,7 @@ def parse_services():
             json.dump(services_dict, backupfile, indent=2)
     print("Found services:")
     for service in services_dict:
-        print(f"\n\t{service}")
+        print(f"\t{service}")
     return services_dict
 
 
@@ -212,7 +212,8 @@ def restart_services():
 
 
 if __name__ == "__main__":
-    os.chdir("..")
+    if Path(os.getcwd()).name == "ctf_proxy":
+        os.chdir("..")
     services_dict = parse_services()
     edit_services()
     configure_proxy()

--- a/setup_proxy.py
+++ b/setup_proxy.py
@@ -131,11 +131,6 @@ def edit_services():
             # add external network
             ymlfile["networks"] = {"default": {"name": "ctf_network", "external": True}}
 
-            # add external volume
-            ymlfile["volumes"] = {
-                "volume_persistente": {"name": "volume_persistente", "external": True}
-            }
-
             # write file
             with open(file, "w") as fs:
                 yaml.dump(ymlfile, fs)

--- a/setup_proxy.py
+++ b/setup_proxy.py
@@ -263,15 +263,22 @@ def main():
         print("Found existing services file")
         with open("./services.json", "r") as fs:
             services_dict = json.load(fs)
-    else:
-        parse_dirs()
-        parse_services()
+
+    if "RESTART" in sys.argv:
+        if not services_dict:
+            print(
+                f"Can't restart without first parsing the services. Please run the script at least once without the RESTART flag"
+            )
+        else:
+            restart_services()
+        return
+
+    parse_dirs()
+    parse_services()
     make_backup()
 
-    if "RESTART" not in sys.argv:
-        print("\n")
-        edit_services()
-        configure_proxy()
+    edit_services()
+    configure_proxy()
     confirmation = input(
         "You are about to restart all your services! Make sure that no catastrophic configuration error has occurred.\nPress Enter to continue"
     )

--- a/setup_proxy.py
+++ b/setup_proxy.py
@@ -1,0 +1,222 @@
+#!/usr/bin/python3
+
+import os
+import json
+
+import ruamel.yaml  # pip install ruamel.yaml
+
+"""
+Why not just use the included yaml package?
+Because this one preservs order and comments (and also allows adding them)
+"""
+
+from pathlib import Path
+
+
+yaml = ruamel.yaml.YAML()
+yaml.preserve_quotes = True
+yaml.indent(sequence=3, offset=1)
+
+services_dict = {}
+
+
+def parse_services():
+    """
+    If services.json is present, load it into the global dictionary.
+    Otherwise, parse all the docker-compose yamls to build the dictionary and
+    then save the result into services.json
+    """
+    dirs = []
+
+    if Path("./services.json").exists():
+        print("Found existing services file")
+        with open("./services.json", "r") as fs:
+            services_dict = json.load(fs)
+    else:
+        services_dict = {}
+        for file in Path(".").iterdir():
+            if (
+                file.is_dir()
+                and file.stem[0] != "."
+                and file.stem
+                not in ["remote_pcap_folder", "caronte", "tulip", "ctf_proxy"]
+            ):
+                dirs.append(Path(".", file))
+
+        for service in dirs:
+            file = Path(service, "docker-compose.yml")
+            if not file.exists():
+                file = Path(service, "docker-compose.yaml")
+
+            with open(file, "r") as fs:
+                ymlfile = yaml.load(file)
+
+            for container in ymlfile["services"]:
+                try:
+                    ports_string = ymlfile["services"][container]["ports"]
+                    ports_list = [p.split(":") for p in ports_string]
+
+                    http = []
+                    for port in ports_list:
+                        http.append(
+                            True
+                            if "y"
+                            in input(
+                                f"Is the service {service.stem}:{port[-2]} http? (y/n) "
+                            )
+                            else False
+                        )
+
+                    container_dict = {
+                        "target_port": [p[-1] for p in ports_list],
+                        "listen_port": [p[-2] for p in ports_list],
+                        "http": [h for h in http],
+                    }
+                    services_dict[service.stem] = {container: container_dict}
+
+                except KeyError:
+                    print(f"{service.stem}_{container} has no ports binding")
+                except Exception as e:
+                    raise e
+
+        with open("services.json", "w") as backupfile:
+            json.dump(services_dict, backupfile, indent=2)
+    print("Found services:")
+    for service in services_dict:
+        print(f"\n\t{service}")
+    return services_dict
+
+
+def edit_services():
+    """
+    Prepare the docker-compose for each service; comment out the ports, add hostname, add the external network, add an external volume for data persistence (this alone isn't enough - it' s just for convenience since we are already here)
+    """
+    global services_dict
+
+    for service in services_dict:
+        file = Path(service, "docker-compose.yml")
+        if not file.exists():
+            file = Path(service, "docker-compose.yaml")
+
+        with open(file, "r") as fs:
+            ymlfile = yaml.load(file)
+
+        for container in services_dict[service]:
+            try:
+                # Add a comment with the ports
+                target_ports = services_dict[service][container]["target_port"]
+                listen_ports = services_dict[service][container]["listen_port"]
+                ports_string = "ports: "
+                for target, listen in zip(target_ports, listen_ports):
+                    ports_string += f"- {listen}:{target} "
+
+                ymlfile["services"].yaml_add_eol_comment(ports_string, container)
+
+                # Remove the actual port bindings
+                try:
+                    ymlfile["services"][container].pop("ports")
+                except KeyError:
+                    pass  # this means we had already had removed them
+
+                # Add hostname
+                hostname = f"{service}_{container}"
+                ymlfile["services"][container]["hostname"] = hostname
+
+            except Exception as e:
+                print(ymlfile)
+                raise e
+
+            # TODO: Add restart: always
+
+            # add external network
+            ymlfile["networks"] = {"default": {"name": "ctf_network", "external": True}}
+
+            # add external volume
+            ymlfile["volumes"] = {
+                "volume_persistente": {"name": "volume_persistente", "external": True}
+            }
+
+            # write file
+            with open(file, "w") as fs:
+                yaml.dump(ymlfile, fs)
+
+
+def configure_proxy():
+    """
+    Properly configure both the proxy's docker-compose with the listening ports and the config.json with all the services.
+    We can't automatically configure ssl for now, so it's better to set https services as not http so they keep working at least. Manually configure the SSL later and turn http back on.
+    """
+    global services_dict
+
+    # Download ctf_proxy
+    if not Path("./ctf_proxy").exists():
+        os.system("git clone https://github.com/ByteLeMani/ctf_proxy.git")
+
+    with open("./ctf_proxy/docker-compose.yml", "r") as file:
+        ymlfile = yaml.load(file)
+
+    # Add all the ports to the compose
+    ports = []
+    for service in services_dict:
+        for container in services_dict[service]:
+            for port in services_dict[service][container]["listen_port"]:
+                ports.append(f"{port}:{port}")
+    ymlfile["services"]["proxy"]["ports"] = ports
+    with open("./ctf_proxy/docker-compose.yml", "w") as fs:
+        yaml.dump(ymlfile, fs)
+
+    # Proxy config.json
+    print("Remember to manually edit the config for SSL")
+    services = []
+    for service in services_dict:
+        for container in services_dict[service]:
+            name = f"{service}_{container}"
+            target_ports = services_dict[service][container]["target_port"]
+            listen_ports = services_dict[service][container]["listen_port"]
+            http = services_dict[service][container]["http"]
+            for i, (target, listen) in enumerate(zip(target_ports, listen_ports)):
+                services.append(
+                    {
+                        "name": name + str(i),
+                        "target_ip": name,
+                        "target_port": int(target),
+                        "listen_port": int(listen),
+                        "http": http[i],
+                    }
+                )
+
+    with open("./ctf_proxy/proxy/config/config.json", "r") as fs:
+        proxy_config = json.load(fs)
+    proxy_config["services"] = services
+    with open("./ctf_proxy/proxy/config/config.json", "w") as fs:
+        json.dump(proxy_config, fs, indent=2)
+
+
+def restart_services():
+    global services_dict
+    # With the config done, make sure every service is off and then start them one by one
+
+    for service in services_dict:
+        os.system(
+            f"bash -c '!(docker compose --file {service}/docker-compose.yml down) && docker compose --file {service}/docker-compose.yaml down'"
+        )
+
+    os.system(
+        f"bash -c 'docker compose --file ctf_proxy/docker-compose.yml restart; docker compose --file ctf_proxy/docker-compose.yml up -d'"
+    )
+
+    for service in services_dict:
+        os.system(
+            f"bash -c '!(docker compose --file {service}/docker-compose.yml up -d) && docker compose --file {service}/docker-compose.yaml up -d'"
+        )
+
+
+if __name__ == "__main__":
+    os.chdir("..")
+    services_dict = parse_services()
+    edit_services()
+    configure_proxy()
+    confirmation = input(
+        "You are about to restart all your services! Make sure that no catastrophic configuration error has occurred.\nPress Enter to continue"
+    )
+    restart_services()


### PR DESCRIPTION
The provided script automatically parses the services' docker-compose and builds a dictionary with all the port bindings, asking the user if a given service should be considered http or not. After that, it comments out all the ports from the compose files, adds an explicit hostname and adds the proxy's external network. It clones ctf_proxy if it wasn't already there, adds all the ports to the compose and each service to config.json. The global_config section is left untouched.
I don't think it's possible in any way to automate the ssl config so that remains manual. 

It works if you run it from inside the ctf_proxy directory or outside, besides the services.


Note that if a service is only listening on a specific IP we will lose that information since it gets discarded while parsing the ports and it will **not** be in the comments either.
This is not intended as a be-all end-all solution, but as a way to get the proxy running faster and avoiding hard to notice errors like typos